### PR TITLE
Allow iptables chains parameter to be an array (fix #237)

### DIFF
--- a/spec/classes/collectd_plugin_iptables_spec.rb
+++ b/spec/classes/collectd_plugin_iptables_spec.rb
@@ -18,6 +18,26 @@ describe 'collectd::plugin::iptables', :type => :class do
     end
   end
 
+  context ':ensure => present and :chains has two chains from the same table' do
+    let :params do
+      { :chains => {
+        'filter' => ['INPUT','OUTPUT'],
+      } }
+    end
+    it 'Will create /etc/collectd.d/10-iptables.conf' do
+      should contain_file('iptables.load').with({
+        :ensure  => 'present',
+        :path    => '/etc/collectd.d/10-iptables.conf',
+        :content => /Chain filter INPUT/,
+      })
+      should contain_file('iptables.load').with({
+        :ensure  => 'present',
+        :path    => '/etc/collectd.d/10-iptables.conf',
+        :content => /Chain filter OUTPUT/,
+      })
+    end
+  end
+
   context ':ensure => absent' do
     let :params do
       {:chains => { 'nat' => 'In_SSH' }, :ensure => 'absent'}

--- a/templates/plugin/iptables.conf.erb
+++ b/templates/plugin/iptables.conf.erb
@@ -3,7 +3,7 @@
 <%   @chains.each_pair do |table,chains|
        Array(chains).each do |chain| -%>
   Chain <%= table %> <%= chain %>
-<%     end
-     end -%>
+<%     end -%>
+<%   end -%>
 </Plugin>
 <% end -%>

--- a/templates/plugin/iptables.conf.erb
+++ b/templates/plugin/iptables.conf.erb
@@ -1,7 +1,9 @@
 <% if @chains -%>
 <Plugin iptables>
-<%   @chains.each_pair do |table,chain| -%>
+<%   @chains.each_pair do |table,chains|
+       Array(chains).each do |chain| -%>
   Chain <%= table %> <%= chain %>
-<%   end -%>
+<%     end
+     end -%>
 </Plugin>
 <% end -%>


### PR DESCRIPTION
When using the iptables plugin, this allows you to provide more than one chain for each table by passing an array as the hash value. For example:

```puppet
class { 'collectd::plugin::iptables':
  chains  => {
    'filter' => ['INPUT','OUTPUT'],
  },
}
```