### PR TITLE
Add support for the AllPortsSummary option added in collectd 5.5.0.

### DIFF
--- a/manifests/plugin/tcpconns.pp
+++ b/manifests/plugin/tcpconns.pp
@@ -1,11 +1,11 @@
 # https://collectd.org/wiki/index.php/Plugin:TCPConns
 class collectd::plugin::tcpconns (
-  $localports  = undef,
-  $remoteports = undef,
-  $listening   = undef,
-  $interval    = undef,
-  $summary     = undef,
-  $ensure      = present
+  $localports      = undef,
+  $remoteports     = undef,
+  $listening       = undef,
+  $interval        = undef,
+  $allportssummary = undef,
+  $ensure          = present
 ) {
 
   if $localports {
@@ -16,8 +16,8 @@ class collectd::plugin::tcpconns (
     validate_array($remoteports)
   }
 
-  if $summary {
-    validate_bool($summary)
+  if $allportssummary {
+    validate_bool($allportssummary)
   }
 
   collectd::plugin {'tcpconns':

--- a/manifests/plugin/tcpconns.pp
+++ b/manifests/plugin/tcpconns.pp
@@ -4,6 +4,7 @@ class collectd::plugin::tcpconns (
   $remoteports = undef,
   $listening   = undef,
   $interval    = undef,
+  $summary     = undef,
   $ensure      = present
 ) {
 

--- a/manifests/plugin/tcpconns.pp
+++ b/manifests/plugin/tcpconns.pp
@@ -16,6 +16,10 @@ class collectd::plugin::tcpconns (
     validate_array($remoteports)
   }
 
+  if $summary {
+    validate_bool($summary)
+  }
+
   collectd::plugin {'tcpconns':
     ensure   => $ensure,
     content  => template('collectd/plugin/tcpconns.conf.erb'),

--- a/spec/classes/collectd_plugin_tcpconns_spec.rb
+++ b/spec/classes/collectd_plugin_tcpconns_spec.rb
@@ -70,7 +70,7 @@ describe 'collectd::plugin::tcpconns', :type => :class do
     end
   end
 
-  context ':allportssummary should not be included with version < 5.5.0' do
+  context ':allportssummary => true with collectd_version < 5.5.0' do
     let :facts do
       { :osfamily => 'RedHat', :collectd_version => '5.4.1' }
     end
@@ -78,12 +78,12 @@ describe 'collectd::plugin::tcpconns', :type => :class do
       { :ensure  => 'present', :allportssummary => true }
     end
 
-    it 'Should not include AllPortsSummary in /etc/collectd.d/10-tcpconns.conf for collectd < 5.5.0' do
-      should contain_file('10-tcpconns.load').without_content(/.*AllPortsSummary.*/)
+    it 'Should not include AllPortsSummary in /etc/collectd.d/10-tcpconns.conf' do
+      should contain_file('tcpconns.load').without_content(/AllPortsSummary/)
     end
   end
-
-  context ':allportssummary should be included with version >= 5.5.0' do
+  
+  context ':allportssummary => true with collectd_version = 5.5.0' do
     let :facts do
       { :osfamily => 'RedHat', :collectd_version => '5.5.0' }
     end
@@ -91,8 +91,10 @@ describe 'collectd::plugin::tcpconns', :type => :class do
       { :ensure  => 'present', :allportssummary => true }
     end
 
-    it 'Should be included in /etc/collectd.d/10-tcpconns.conf for collectd >= 5.5.0' do
-      should contain_file('10-tcpconns.load').with_content(/.*AllPortsSummary true.*/)
+    it 'Should include AllPortsSummary in /etc/collectd.d/10-tcpconns.conf' do
+      should contain_file('tcpconns.load').with_content(/AllPortsSummary true/)
     end
   end
+
+
 end

--- a/spec/classes/collectd_plugin_tcpconns_spec.rb
+++ b/spec/classes/collectd_plugin_tcpconns_spec.rb
@@ -60,17 +60,39 @@ describe 'collectd::plugin::tcpconns', :type => :class do
       expect {should}.to raise_error(Puppet::Error,/String/)
     end
   end
-  
-  context ':collectd_version >= 5.5.0, :summary is not a boolean' do
+
+  context ':allportssummary is not a boolean' do
+    let :params do
+      { :allportssummary => 'aString' }
+    end
+    it 'Will raise an error about :allportssummary being a String' do
+      expect { should.to raise_error(Puppet::Error,/String/) }
+    end
+  end
+
+  context ':allportssummary should not be included with version < 5.5.0' do
     let :facts do
-      { :collectd_version => '5.5.0' }
+      { :osfamily => 'RedHat', :collectd_version => '5.4.1' }
     end
     let :params do
-      { :summary => 'aString' }
+      { :ensure  => 'present', :allportssummary => true }
     end
-    it 'Will raise an error about :summary being a String' do
-      expect {should}.to raise_error(Puppet::Error, /String/)
-    end
-  end 
-end
 
+    it 'Should not include AllPortsSummary in /etc/collectd.d/10-tcpconns.conf for collectd < 5.5.0' do
+      should contain_file('10-tcpconns.load').without_content(/.*AllPortsSummary.*/)
+    end
+  end
+
+  context ':allportssummary should be included with version >= 5.5.0' do
+    let :facts do
+      { :osfamily => 'RedHat', :collectd_version => '5.5.0' }
+    end
+    let :params do
+      { :ensure  => 'present', :allportssummary => true }
+    end
+
+    it 'Should be included in /etc/collectd.d/10-tcpconns.conf for collectd >= 5.5.0' do
+      should contain_file('10-tcpconns.load').with_content(/.*AllPortsSummary true.*/)
+    end
+  end
+end

--- a/spec/classes/collectd_plugin_tcpconns_spec.rb
+++ b/spec/classes/collectd_plugin_tcpconns_spec.rb
@@ -60,5 +60,17 @@ describe 'collectd::plugin::tcpconns', :type => :class do
       expect {should}.to raise_error(Puppet::Error,/String/)
     end
   end
+  
+  context ':collectd_version >= 5.5.0, :summary is not a boolean' do
+    let :facts do
+      { :collectd_version => '5.5.0' }
+    end
+    let :params do
+      { :summary => 'aString' }
+    end
+    it 'Will raise an error about :summary being a String' do
+      expect {should}.to raise_error(Puppet::Error, /String/)
+    end
+  end 
 end
 

--- a/templates/plugin/tcpconns.conf.erb
+++ b/templates/plugin/tcpconns.conf.erb
@@ -13,7 +13,7 @@
   RemotePort "<%= remoteport %>"
 <%   end -%>
 <% end -%>
-<% if @allportssummary and @collectd_version and (scope.function_versioncmp([@collectd_version, '5.5.0']) >= 0)-%>
+<% if @allportssummary and @collectd_version and (scope.function_versioncmp([@collectd_version, '5.5.0']) >= 0) -%>
   AllPortsSummary <%= @allportssummary %>
 <% end -%>
 </Plugin>

--- a/templates/plugin/tcpconns.conf.erb
+++ b/templates/plugin/tcpconns.conf.erb
@@ -13,4 +13,7 @@
   RemotePort "<%= remoteport %>"
 <%   end -%>
 <% end -%>
+<% if @summary and @collectd_version and (scope.function_versioncmp([@collectd_version, '5.5']) >= 0)-%>
+  AllPortsSummary <%= @summary %>
+<% end -%>
 </Plugin>

--- a/templates/plugin/tcpconns.conf.erb
+++ b/templates/plugin/tcpconns.conf.erb
@@ -13,7 +13,7 @@
   RemotePort "<%= remoteport %>"
 <%   end -%>
 <% end -%>
-<% if @summary and @collectd_version and (scope.function_versioncmp([@collectd_version, '5.5']) >= 0)-%>
-  AllPortsSummary <%= @summary %>
+<% if @allportssummary and @collectd_version and (scope.function_versioncmp([@collectd_version, '5.5.0']) >= 0)-%>
+  AllPortsSummary <%= @allportssummary %>
 <% end -%>
 </Plugin>


### PR DESCRIPTION
Collectd version 5.5.0 added the AllPortsSummary option to the tcpconns module.  This patch adds support for that option.