### PR TITLE
Release 4.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,29 @@
 sudo: false
 language: ruby
 bundler_args: --without system_tests
+before_install: rm Gemfile.lock || true
 script:
-  - 'puppet --version'
-  - 'bundle exec rake validate'
-  - 'bundle exec rake lint'
-  - "bundle exec rake spec SPEC_OPTS='--format documentation'"
+  - 'bundle exec rake test'
 matrix:
   fast_finish: true
   include:
   - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES="yes"
+    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes"
   - rvm: 2.1.6
-    env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES="yes"
+    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes"
   - rvm: 2.1.6
-    env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
+    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes"
   - rvm: 2.2.0
-    env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
+    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes"
 notifications:
   email: false
+deploy:
+  provider: puppetforge
+  user: puppet
+  password:
+    secure: "FAK3Izs5bSZyblGvcFnGWm0exZV5+v9pbwfRDD2oihWxX3U3pArGW+3XcwcJfLQgrUYBsOTmHC8yPjlgTBYeIt/5pvg9X+3jwNgeto6kozpI/nvAq4NtcHhzxRejuPELhFYeXZ3hEw0w+v/ZRo2cNLwI0LLpiWEDvCMZN1CJ2RY="
+    tags: true
+    # all_branches is required to use tags
+    all_branches: true
+    # Only publish if our main Ruby target builds
+    rvm: 1.9.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2015-07-26 Release 4.1.0
+
+This module now lives on the puppet community github organization.
+
+### New features
+
+* Add option to not install collectd-iptables on centos 6
+* Allow iptables chains parameter to be an array
+* Support UdevNameAttr attribute on disk plugin (fixes #300)
+
 ## 2015-07-26 Release 4.0.0
 
 ### Backwards-incompatible changes:

--- a/Gemfile
+++ b/Gemfile
@@ -1,31 +1,37 @@
-source ENV['GEM_SOURCE'] || "https://rubygems.org"
+#  Copyright 2014 Puppet Community
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 
-group :development, :unit_tests do
-  gem 'rake', :require => false
-  gem 'rspec-puppet', :require => false
-  gem 'puppetlabs_spec_helper', :require => false
-  gem 'puppet-lint', :require => false
-  gem 'simplecov', :require => false
-  gem 'puppet_facts', :require => false
-  gem 'json', :require => false
-  gem 'metadata-json-lint', :require => false
+source "https://rubygems.org"
+
+group :test do
+  gem "rake"
+  gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.8.0'
+  gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
+  gem "puppetlabs_spec_helper"
+  gem "metadata-json-lint"
+  gem "rspec-puppet-facts"
+  gem "rspec"
+  gem "puppet-blacksmith", "> 3.3.0", :platforms => [:ruby_19, :ruby_20, :ruby_21]
+end
+
+group :development do
+  gem "travis"
+  gem "travis-lint"
+  gem "guard-rake"
 end
 
 group :system_tests do
-  gem 'beaker-rspec', :require => false
-  gem 'serverspec', :require => false
+  gem "beaker"
+  gem "beaker-rspec"
 end
-
-if facterversion = ENV['FACTER_GEM_VERSION']
-  gem 'facter', facterversion, :require => false
-else
-  gem 'facter', :require => false
-end
-
-if puppetversion = ENV['PUPPET_GEM_VERSION']
-  gem 'puppet', puppetversion, :require => false
-else
-  gem 'puppet', :require => false
-end
-
-# vim:ft=ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,15 @@
+GIT
+  remote: https://github.com/rodjek/rspec-puppet.git
+  revision: 369d729a36ee99232d8fe5586d3a3803ee4e7318
+  specs:
+    rspec-puppet (2.2.1.pre)
+      rspec
+
 GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (2.2.8)
-    activesupport (4.2.2)
+    activesupport (4.2.3)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -18,7 +25,8 @@ GEM
     aws-sdk-v1 (1.64.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
-    beaker (2.14.1)
+    backports (3.6.6)
+    beaker (2.18.3)
       aws-sdk (~> 1.57)
       docker-api
       fission (~> 0.4)
@@ -30,34 +38,42 @@ GEM
       minitest (~> 5.4)
       net-scp (~> 1.2)
       net-ssh (~> 2.9)
+      open_uri_redirections (~> 0.2.1)
       rbvmomi (~> 1.8)
       rsync (~> 1.0.9)
       unf (~> 0.1)
-    beaker-rspec (5.1.0)
+    beaker-rspec (5.2.0)
       beaker (~> 2.0)
       rspec
       serverspec (~> 2)
       specinfra (~> 2)
     builder (3.2.2)
+    coderay (1.1.0)
     diff-lcs (1.2.5)
-    docile (1.1.5)
-    docker-api (1.21.4)
+    docker-api (1.22.2)
       excon (>= 0.38.0)
       json
-    excon (0.45.3)
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
+    ethon (0.7.4)
+      ffi (>= 1.3.0)
+    excon (0.45.4)
     extlib (0.9.16)
     facter (2.4.4)
       CFPropertyList (~> 2.2.6)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.10.0)
+      faraday (>= 0.7.4, < 0.10)
+    ffi (1.9.10)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
-    fog (1.31.0)
+    fog (1.32.0)
       fog-atmos
-      fog-aws (~> 0.0)
+      fog-aws (>= 0.6.0)
       fog-brightbox (~> 0.4)
-      fog-core (~> 1.30)
-      fog-ecloud
+      fog-core (~> 1.32)
+      fog-ecloud (= 0.1.1)
       fog-google (>= 0.0.2)
       fog-json
       fog-local
@@ -78,26 +94,26 @@ GEM
     fog-atmos (0.1.0)
       fog-core
       fog-xml
-    fog-aws (0.4.1)
+    fog-aws (0.7.4)
       fog-core (~> 1.27)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
       ipaddress (~> 0.8)
-    fog-brightbox (0.7.1)
+    fog-brightbox (0.8.0)
       fog-core (~> 1.22)
       fog-json
       inflecto (~> 0.0.2)
-    fog-core (1.30.0)
+    fog-core (1.32.0)
       builder
       excon (~> 0.45)
       formatador (~> 0.2)
       mime-types
       net-scp (~> 1.1)
       net-ssh (>= 2.1.3)
-    fog-ecloud (0.1.3)
+    fog-ecloud (0.1.1)
       fog-core
       fog-xml
-    fog-google (0.0.5)
+    fog-google (0.0.7)
       fog-core
       fog-json
       fog-xml
@@ -110,7 +126,7 @@ GEM
       fog-core (~> 1.27)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
-    fog-profitbricks (0.0.3)
+    fog-profitbricks (0.0.5)
       fog-core
       fog-xml
       nokogiri
@@ -128,7 +144,7 @@ GEM
     fog-serverlove (0.1.2)
       fog-core
       fog-json
-    fog-softlayer (0.4.6)
+    fog-softlayer (0.4.7)
       fog-core
       fog-json
     fog-storm_on_demand (0.1.1)
@@ -147,6 +163,13 @@ GEM
       fog-core
       nokogiri (~> 1.5, >= 1.5.11)
     formatador (0.2.5)
+    gh (0.14.0)
+      addressable
+      backports
+      faraday (~> 0.8)
+      multi_json (~> 1.0)
+      net-http-persistent (>= 2.7)
+      net-http-pipeline
     google-api-client (0.8.6)
       activesupport (>= 3.2)
       addressable (~> 2.3)
@@ -165,27 +188,47 @@ GEM
       memoist (~> 0.12)
       multi_json (= 1.11)
       signet (~> 0.6)
-    hiera (2.0.0)
+    guard (2.13.0)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, <= 4.0)
+      lumberjack (~> 1.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.9.12)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-rake (1.0.0)
+      guard
+      rake
+    hiera (1.3.4)
       json_pure
-    hocon (0.9.0)
+    highline (1.7.3)
+    hocon (0.9.3)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     i18n (0.7.0)
     inflecto (0.0.2)
     inifile (2.0.2)
     ipaddress (0.8.0)
     json (1.8.3)
     json_pure (1.8.2)
-    jwt (1.5.0)
+    jwt (1.5.1)
     launchy (2.4.3)
       addressable (~> 2.3)
+    listen (3.0.3)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
     little-plugger (1.1.3)
     logging (2.0.0)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
+    lumberjack (1.0.9)
     memoist (0.12.0)
     metaclass (0.0.4)
     metadata-json-lint (0.0.6)
       json
       spdx-licenses (~> 1.0)
+    method_source (0.8.2)
     mime-types (2.6.1)
     mini_portile (0.6.2)
     minitest (5.7.0)
@@ -193,92 +236,139 @@ GEM
       metaclass (~> 0.0.1)
     multi_json (1.11.0)
     multipart-post (2.0.0)
+    nenv (0.2.0)
+    net-http-persistent (2.9.4)
+    net-http-pipeline (1.0.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
+    net-telnet (0.1.1)
+    netrc (0.10.3)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
-    puppet (4.1.0)
-      facter (> 2.0, < 4)
-      hiera (>= 2.0, < 3)
+    notiffany (0.0.7)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
+    open_uri_redirections (0.2.1)
+    pry (0.9.12.6)
+      coderay (~> 1.0)
+      method_source (~> 0.8)
+      slop (~> 3.4)
+    puppet (3.8.1)
+      facter (> 1.6, < 3)
+      hiera (~> 1.0)
       json_pure
+    puppet-blacksmith (3.3.1)
+      puppet (>= 2.7.16)
+      rest-client
     puppet-lint (1.1.0)
     puppet-syntax (2.0.0)
       rake
-    puppet_facts (0.2.1)
     puppetlabs_spec_helper (0.10.3)
       mocha
       puppet-lint
       puppet-syntax
       rake
       rspec-puppet
+    pusher-client (0.6.2)
+      json
+      websocket (~> 1.0)
     rake (10.4.2)
+    rb-fsevent (0.9.5)
+    rb-inotify (0.9.5)
+      ffi (>= 0.5.0)
     rbvmomi (1.8.2)
       builder
       nokogiri (>= 1.4.1)
       trollop
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     retriable (1.4.1)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
       rspec-expectations (~> 3.3.0)
       rspec-mocks (~> 3.3.0)
-    rspec-core (3.3.0)
+    rspec-core (3.3.2)
       rspec-support (~> 3.3.0)
-    rspec-expectations (3.3.0)
+    rspec-expectations (3.3.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
     rspec-its (1.2.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
-    rspec-mocks (3.3.0)
+    rspec-mocks (3.3.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
-    rspec-puppet (2.2.0)
-      rspec
+    rspec-puppet-facts (0.11.0)
+      facter
+      json
     rspec-support (3.3.0)
     rsync (1.0.9)
-    serverspec (2.18.0)
+    serverspec (2.20.0)
       multi_json
       rspec (~> 3.0)
       rspec-its
-      specinfra (~> 2.35)
+      specinfra (~> 2.38)
+    sfl (2.2)
+    shellany (0.0.1)
     signet (0.6.1)
       addressable (~> 2.3)
       extlib (~> 0.9)
       faraday (~> 0.9)
       jwt (~> 1.5)
       multi_json (~> 1.10)
-    simplecov (0.10.0)
-      docile (~> 1.1.0)
-      json (~> 1.8)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.0)
+    slop (3.6.0)
     spdx-licenses (1.0.0)
       json
-    specinfra (2.36.0)
+    specinfra (2.40.0)
       net-scp
-      net-ssh
+      net-ssh (~> 2.7)
+      net-telnet
+      sfl
+    thor (0.19.1)
     thread_safe (0.3.5)
+    travis (1.8.0)
+      addressable (~> 2.3)
+      backports
+      faraday (~> 0.9)
+      faraday_middleware (~> 0.9, >= 0.9.1)
+      gh (~> 0.13)
+      highline (~> 1.6)
+      launchy (~> 2.1)
+      pry (~> 0.9, < 0.10)
+      pusher-client (~> 0.4)
+      typhoeus (~> 0.6, >= 0.6.8)
+    travis-lint (2.0.0)
+      json
     trollop (2.1.2)
+    typhoeus (0.7.2)
+      ethon (>= 0.7.4)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
+    websocket (1.2.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  beaker
   beaker-rspec
-  facter
-  json
+  guard-rake
   metadata-json-lint
-  puppet
-  puppet-lint
-  puppet_facts
+  puppet (~> 3.8.0)
+  puppet-blacksmith (> 3.3.0)
   puppetlabs_spec_helper
   rake
-  rspec-puppet
-  serverspec
-  simplecov
+  rspec
+  rspec-puppet!
+  rspec-puppet-facts
+  travis
+  travis-lint
+
+BUNDLED WITH
+   1.10.6

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,60 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
+require 'puppet-syntax/tasks/puppet-syntax'
+require 'metadata-json-lint/rake_task'
 
 PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.send('disable_80chars')
 PuppetLint.configuration.send('disable_class_inherits_from_params_class')
 PuppetLint.configuration.send('disable_class_parameter_defaults')
 PuppetLint.configuration.send('disable_documentation')
-PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
+
+# These two gems aren't always present, for instance
+# on Travis with --without development
+begin
+  require 'puppet_blacksmith/rake_tasks'
+rescue LoadError
+end
+
+exclude_paths = [
+  "pkg/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+PuppetLint.configuration.ignore_paths = exclude_paths
+PuppetSyntax.exclude_paths = exclude_paths
+
+desc "Run acceptance tests"
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  t.pattern = 'spec/acceptance'
+end
+
+desc "Run metadata_lint, lint, syntax, and spec tests."
+task :test => [
+  :metadata_lint,
+  :lint,
+  :syntax,
+  :spec,
+]
+
+if RUBY_VERSION >= "1.9.0" and RUBY_VERSION < "2.2.0" then
+  Blacksmith::RakeTask.new do |t|
+    t.build = false # do not build the module nor push it to the Forge
+    # just do the tagging [:clean, :tag, :bump_commit]
+  end
+
+
+  desc "Offload release process to Travis."
+  task :travis_release => [
+    :check_changelog,  # check that the changelog contains an entry for the current release
+    :"module:release", # do everything except build / push to forge, travis will do that for us
+  ]
+
+  desc "Check Changelog."
+  task :check_changelog do
+    v = Blacksmith::Modulefile.new.version
+    if File.readlines('CHANGELOG.md').grep("Releasing #{v}").size == 0 then
+      fail "Unable to find a CHANGELOG.md entry for the #{v} release."
+    end
+  end
+end

--- a/metadata.json
+++ b/metadata.json
@@ -70,7 +70,7 @@
     }
   ],
   "name": "puppet-collectd",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "source": "https://github.com/puppet-community/puppet-collectd",
   "author": "puppetcommunity",
   "license": "Apache-2.0",


### PR DESCRIPTION
This module now lives on the puppet community github organization.

New features:

* Add option to not install collectd-iptables on centos 6
* Allow iptables chains parameter to be an array
* Support UdevNameAttr attribute on disk plugin (fixes #300)