### PR TITLE
Add Plugin Filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ documentation for each plugin for configurable attributes.
 * `entropy`  (see [collectd::plugin::entropy](#class-collectdpluginentropy) below)
 * `exec`  (see [collectd::plugin::exec](#class-collectdpluginexec) below)
 * `filecount` (see [collectd::plugin::filecount](#class-collectdpluginfilecount) below)
+* `filter`  (see [collectd::plugin::filter](#class-collectdpluginfilter) below)
 * `genericjmx` (see [collectd::plugin::genericjmx](#class-collectdplugingenericjmx) below)
 * `interface` (see [collectd::plugin::interface](#class-collectdplugininterface) below)
 * `iptables` (see [collectd::plugin::iptables](#class-collectdpluginiptables) below)
@@ -376,6 +377,137 @@ class { 'collectd::plugin::filecount':
   },
 }
 ```
+
+#### Class: `collectd::plugin::filter`
+
+The filter plugin implements the powerful filter configuration of collectd. For further details have a look on the [collectd manpage](https://collectd.org/documentation/manpages/collectd.conf.5.shtml#filter_configuration).
+
+##### Parameters:
+
+* `ensure` (`"ensure"`,`"absent"`): Ob absent it will remove all references of the filter plugins. `Note`: The Chain config needs to be purged by the chain define.
+* `precachechain` (String): The Name of the default Pre Chain.
+* `postcachechain` (String): The Name of the default Post Chain.
+
+##### Examples:
+
+###### Overwrite default chains:
+```puppet
+class { 'collectd::plugin::filter':
+    ensure          => 'present',
+    precachechain   => 'PreChain',
+    postcachechain  => 'PostChain',
+}
+```
+
+###### Full Example:
+
+This Example will rename the hostname of the mysql plugin.
+
+```puppet
+include collectd::plugin::filter
+
+# define default chains with default target
+collectd::plugin::filter::chain { 'PreChain':
+    target => 'return'
+}
+collectd::plugin::filter::chain { 'PostChain':
+    target => 'write'
+}
+
+# create a third chain,
+$chainname = 'MyAweseomeChain'
+collectd::plugin::filter::chain { $chainname:
+    ensure => present,
+    target => 'return'
+}
+
+# add a new rule to chain
+$rulename = 'MyAweseomeRule'
+collectd::plugin::filter::rule { $rulename:
+    chain => $chainname,
+}
+
+# add a new match rule, match metrics of the mysql plugin
+collectd::plugin::filter::match { "Match mysql plugin":
+    chain   => $chainname,
+    rule    => $rulename,
+    plugin  => 'regex',
+    options => {
+        'Plugin' => '^mysql',
+    }
+}
+
+#rewrite hostname
+collectd::plugin::filter::target{ "overwrite hostname":
+    chain   => $chainname,
+    rule    => $rulename,
+    plugin  => 'set',
+    options => {
+        'Host' => 'hostname.domain',
+    },
+}
+
+# hook the configured chain in the prechain
+collectd::plugin::filter::target{ "1_prechain_jump_${chainname}":
+    chain   => 'PreChain',
+    plugin  => 'jump',
+    options => {
+        'Chain' => $chainname,
+    },
+}
+```
+
+#### Define: `collectd::plugin::filter::chain`
+
+This define will create a new chain, which is required by targets, matches and rules.
+
+##### Parameters:
+
+* `ensure` (`"ensure"`,`"absent"`): When set to absent it will remove the chain with all assigned rules, targets and matches.
+* `target` (`'notification','replace','set','return','stop','write','jump'`): Optional. Set default target if no target has been applied. Strongly recommend for default chains.
+* `target_options` (Hash): If target is specified, pass optional hash to define.
+
+##### Example:
+see [collectd::plugin::filter](#class-collectdpluginfilter) above
+
+#### Define: `collectd::plugin::filter::rule`
+
+This define will add a new rule to a specific chain
+
+##### Parameters:
+
+* `chain` (String): Assign to this chain.
+
+##### Example:
+see [collectd::plugin::filter](#class-collectdpluginfilter) above
+
+#### Define: `collectd::plugin::filter::target`
+
+This define will add a target to a chain or rule.
+
+##### Parameters:
+
+* `chain` (String): Assign to this chain.
+* `plugin` (`'notification','replace','set','return','stop','write','jump'`): The plugin of the target.
+* `options` (Hash): Optional parameters of the target plugin.
+* `rule` (String): Optional. Assign to this rule. If not present, target will be applied at the end of chain without rule matching.
+
+##### Example:
+see [collectd::plugin::filter](#class-collectdpluginfilter) above
+
+#### Define: `collectd::plugin::filter::match`
+
+This define will add a match rule.
+
+##### Parameters:
+
+* `chain` (String): Assign to this chain.
+* `rule` (String): Assign to this rule.
+* `plugin` (`'regex','timediff','value','empty_counter','hashed'`): The plugin of the match.
+* `options` (Hash): Optional parameters of the match plugin.
+
+##### Example:
+see [collectd::plugin::filter](#class-collectdpluginfilter) above
 
 ####Class: `collectd::plugin::genericjmx`
 

--- a/manifests/plugin/filter.pp
+++ b/manifests/plugin/filter.pp
@@ -1,0 +1,28 @@
+# https://collectd.org/wiki/index.php/Chains
+class collectd::plugin::filter (
+  $ensure          = 'present',
+  $precachechain   = 'PreChain',
+  $postcachechain  = 'PostChain',
+) {
+  include collectd::params
+
+  $plugin_matches = ['regex','timediff','value','empty_counter','hashed']
+  $plugin_targets = ['notification','replace','set']
+  $conf_file = "${collectd::params::plugin_conf_dir}/01-filter.conf"
+
+  file { $conf_file:
+    ensure  => $ensure,
+    owner   => 'root',
+    group   => $collectd::params::root_group,
+    mode    => '0644',
+    content => "PreCacheChain \"${precachechain}\"\nPostCacheChain \"${postcachechain}\"\n\n",
+    notify  => Service['collectd'],
+  }
+
+  unless $ensure == 'present' {
+    #kick all filter specifc plugins
+    ensure_resource('collectd::plugin', prefix($plugin_matches,'match_'), {'ensure' => 'absent', 'order' => '02'} )
+    ensure_resource('collectd::plugin', prefix($plugin_targets,'target_'), {'ensure' => 'absent', 'order' => '02'} )
+  }
+
+}

--- a/manifests/plugin/filter/chain.pp
+++ b/manifests/plugin/filter/chain.pp
@@ -1,0 +1,44 @@
+# https://collectd.org/wiki/index.php/Chains
+define collectd::plugin::filter::chain (
+  $ensure = 'present',
+  $target = undef,
+  $target_options = undef,
+) {
+  include collectd::params
+  include collectd::plugin::filter
+
+  $conf_file = "${collectd::params::plugin_conf_dir}/filter-chain-${title}.conf"
+
+  concat{ $conf_file:
+    ensure         => $ensure,
+    mode           => '0640',
+    owner          => 'root',
+    group          => $collectd::params::root_group,
+    notify         => Service['collectd'],
+    ensure_newline => true,
+  }
+
+  if $ensure == 'present' {
+      concat::fragment{ "${conf_file}_${title}_head":
+        order   => '00',
+        content => "<Chain \"${title}\">",
+        target  => $conf_file,
+      }
+
+      concat::fragment{ "${conf_file}_${title}_footer":
+        order   => '99',
+        content => '</Chain>',
+        target  => $conf_file,
+      }
+
+      #add simple target if provided at the end
+      if $target {
+        collectd::plugin::filter::target{ "z_chain-${title}-target":
+          chain   => $title,
+          plugin  => $target,
+          rule    => undef,
+          options => $target_options
+        }
+      }
+  }
+}

--- a/manifests/plugin/filter/match.pp
+++ b/manifests/plugin/filter/match.pp
@@ -1,0 +1,26 @@
+# https://collectd.org/wiki/index.php/Chains
+define collectd::plugin::filter::match (
+  $chain,
+  $rule,
+  $plugin,
+  $options = undef,
+) {
+  include collectd::params
+  include collectd::plugin::filter
+
+  unless $plugin in $collectd::plugin::filter::plugin_matches {
+    fail("Unknown match plugin '${plugin}' provided")
+  }
+
+  ensure_resource('collectd::plugin', "match_${plugin}", {'order' => '02'} )
+
+  $fragment_order = "10_${rule}_1_${title}"
+  $conf_file = "${collectd::params::plugin_conf_dir}/filter-chain-${chain}.conf"
+
+  concat::fragment{ "${conf_file}_${fragment_order}":
+    order   => $fragment_order,
+    content => template('collectd/plugin/filter/match.erb'),
+    target  => $conf_file,
+  }
+
+}

--- a/manifests/plugin/filter/rule.pp
+++ b/manifests/plugin/filter/rule.pp
@@ -1,0 +1,23 @@
+# https://collectd.org/wiki/index.php/Chains
+define collectd::plugin::filter::rule (
+  $chain,
+) {
+  include collectd::params
+  include collectd::plugin::filter
+
+  $fragment_order = "10_${title}"
+  $conf_file = "${collectd::params::plugin_conf_dir}/filter-chain-${chain}.conf"
+
+  concat::fragment{ "${conf_file}_${fragment_order}_0":
+    order   => "${fragment_order}_0",
+    content => "  <Rule \"${title}\">",
+    target  => $conf_file,
+  }
+
+  concat::fragment{ "${conf_file}_${fragment_order}_99":
+    order   => "${fragment_order}_99",
+    content => '  </Rule>',
+    target  => $conf_file,
+  }
+
+}

--- a/manifests/plugin/filter/target.pp
+++ b/manifests/plugin/filter/target.pp
@@ -1,0 +1,40 @@
+# https://collectd.org/wiki/index.php/Chains
+define collectd::plugin::filter::target (
+  $chain,
+  $plugin,
+  $options = undef,
+  $rule    = undef,
+) {
+  include collectd::params
+  include collectd::plugin::filter
+
+  unless $plugin in ['return','stop','write', 'jump'] or $plugin in $collectd::plugin::filter::plugin_targets {
+    fail("Unknown rule plugin '${plugin}' provided")
+  }
+
+  # Load plugins
+  if $plugin in $collectd::plugin::filter::plugin_targets {
+    $order = 30
+    ensure_resource('collectd::plugin', "target_${plugin}", {'order' => '02'} )
+  } else {
+    # Built in plugins
+    $order = 50
+  }
+
+  if $rule {
+    # create target in rule
+    $fragment_order = "10_${rule}_${order}_${title}"
+  } else {
+    # create target after rules in chain
+    $fragment_order = "20_${order}_${title}"
+  }
+
+  $conf_file = "${collectd::params::plugin_conf_dir}/filter-chain-${chain}.conf"
+
+  concat::fragment{ "${conf_file}_${fragment_order}":
+    order   => $fragment_order,
+    content => template('collectd/plugin/filter/target.erb'),
+    target  => $conf_file,
+  }
+
+}

--- a/spec/classes/collectd_plugin_filter_spec.rb
+++ b/spec/classes/collectd_plugin_filter_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe 'collectd::plugin::filter', type: :class do
+  let :facts do
+    {
+      osfamily: 'Debian',
+      concat_basedir: tmpfilename('collectd-filter'),
+      id: 'root',
+      kernel: 'Linux',
+      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      collectd_version: '5.0'
+    }
+  end
+  context ':ensure => present and default parameters' do
+    it 'Will create /etc/collectd/conf.d/01-filter.conf to set the default Chains' do
+      should contain_file('/etc/collectd/conf.d/01-filter.conf').with(ensure: 'present',
+                                                                      path: '/etc/collectd/conf.d/01-filter.conf',
+                                                                      content: /PreCacheChain \"PreChain\"\nPostCacheChain \"PostChain\"/)
+    end
+  end
+
+  context ':ensure => present and custom parameters' do
+    let(:params) do
+      {
+        ensure: 'present',
+        precachechain: 'MyPreChain',
+        postcachechain: 'MyPostChain'
+      }
+    end
+    it 'Will create /etc/collectd/conf.d/01-filter.conf to set the default Chains' do
+      should contain_file('/etc/collectd/conf.d/01-filter.conf').with(ensure: 'present',
+                                                                      path: '/etc/collectd/conf.d/01-filter.conf',
+                                                                      content: /PreCacheChain \"MyPreChain\"\nPostCacheChain \"MyPostChain\"/)
+    end
+  end
+
+  context ':ensure => absent' do
+    let(:params) do
+      { ensure: 'absent' }
+    end
+
+    it 'Will remove /etc/collectd/conf.d/01-filter.conf' do
+      should contain_file('/etc/collectd/conf.d/01-filter.conf').with(ensure: 'absent',
+                                                                      path: '/etc/collectd/conf.d/01-filter.conf')
+    end
+
+    it 'Will remove loads of match plugins for filter' do
+      should contain_file('match_regex.load').with(ensure: 'absent', path: '/etc/collectd/conf.d/02-match_regex.conf')
+      should contain_file('match_timediff.load').with(ensure: 'absent', path: '/etc/collectd/conf.d/02-match_timediff.conf')
+      should contain_file('match_value.load').with(ensure: 'absent', path: '/etc/collectd/conf.d/02-match_value.conf')
+      should contain_file('match_empty_counter.load').with(ensure: 'absent', path: '/etc/collectd/conf.d/02-match_empty_counter.conf')
+      should contain_file('match_hashed.load').with(ensure: 'absent', path: '/etc/collectd/conf.d/02-match_hashed.conf')
+    end
+
+    it 'Will remove loads of target plugins for filter' do
+      should contain_file('target_notification.load').with(ensure: 'absent', path: '/etc/collectd/conf.d/02-target_notification.conf')
+      should contain_file('target_replace.load').with(ensure: 'absent', path: '/etc/collectd/conf.d/02-target_replace.conf')
+      should contain_file('target_set.load').with(ensure: 'absent', path: '/etc/collectd/conf.d/02-target_set.conf')
+    end
+  end
+end

--- a/spec/defines/collectd_plugin_filter_chain_spec.rb
+++ b/spec/defines/collectd_plugin_filter_chain_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe 'collectd::plugin::filter::chain', type: :define do
+  let :facts do
+    {
+      osfamily: 'Debian',
+      concat_basedir: tmpfilename('collectd-filter'),
+      id: 'root',
+      kernel: 'Linux',
+      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      collectd_version: '5.0'
+    }
+  end
+
+  context ':ensure => present and default parameters' do
+    let(:title) { 'MyChain' }
+    it 'Will create /etc/collectd/conf.d/filter-chain-MyChain.conf' do
+      should contain_concat('/etc/collectd/conf.d/filter-chain-MyChain.conf').with(ensure: 'present')
+      should contain_concat__fragment('/etc/collectd/conf.d/filter-chain-MyChain.conf_MyChain_head').with(
+        order: '00',
+        content: '<Chain "MyChain">',
+        target: '/etc/collectd/conf.d/filter-chain-MyChain.conf'
+      )
+      should contain_concat__fragment('/etc/collectd/conf.d/filter-chain-MyChain.conf_MyChain_footer').with(
+        order: '99',
+        content: '</Chain>',
+        target: '/etc/collectd/conf.d/filter-chain-MyChain.conf'
+      )
+    end
+    it { should_not contain_collectd__plugin__filter__target('z_chain-MyChain-target') }
+  end
+
+  context ':ensure => present and set a default target' do
+    let(:title) { 'MyChain' }
+    let(:params) do
+      {
+        target: 'set',
+        target_options: {
+          'PluginInstance' => 'coretemp',
+          'TypeInstance'   => 'core3'
+        }
+      }
+    end
+    it 'Will add a default target with plugin set and options' do
+      should contain_collectd__plugin__filter__target('z_chain-MyChain-target').with(
+        chain: 'MyChain',
+        plugin: 'set',
+        options: {
+          'PluginInstance' => 'coretemp',
+          'TypeInstance'   => 'core3'
+        }
+      )
+    end
+  end
+
+  context ':ensure => absent' do
+    let(:title) { 'MyChain' }
+    let(:params) do
+      {
+        ensure: 'absent'
+      }
+    end
+    it 'Will remove file /etc/collectd/conf.d/filter-chain-MyChain.conf' do
+      should contain_concat('/etc/collectd/conf.d/filter-chain-MyChain.conf').with(ensure: 'absent')
+    end
+  end
+end

--- a/spec/defines/collectd_plugin_filter_match_spec.rb
+++ b/spec/defines/collectd_plugin_filter_match_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe 'collectd::plugin::filter::match', type: :define do
+  let :facts do
+    {
+      osfamily: 'Debian',
+      concat_basedir: tmpfilename('collectd-filter'),
+      id: 'root',
+      kernel: 'Linux',
+      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      collectd_version: '5.0'
+    }
+  end
+
+  let(:title) { 'MyMatch' }
+  let(:default_params) { { chain: 'MyChain', rule: 'MyRule' } }
+  let(:concat_fragment_target) { '/etc/collectd/conf.d/filter-chain-MyChain.conf' }
+  let(:concat_fragment_order) { '10_MyRule_1_MyMatch' }
+  let(:concat_fragment_name) { '/etc/collectd/conf.d/filter-chain-MyChain.conf_10_MyRule_1_MyMatch' }
+
+  context 'Add match regex to rule with options' do
+    let(:params) do
+      default_params.merge(plugin: 'regex',
+                           options: {
+                             'Host'   => 'customer[0-9]+',
+                             'Plugin' => '^foobar$'
+                           })
+    end
+    it 'Will ensure that plugin is loaded' do
+      should contain_collectd__plugin('match_regex').with(order: '02')
+    end
+    it 'Will add match to rule' do
+      should contain_concat__fragment(concat_fragment_name).with(
+        order: concat_fragment_order,
+        target: concat_fragment_target
+      )
+      should contain_concat__fragment(concat_fragment_name).with(content: /<Match "regex">/)
+      should contain_concat__fragment(concat_fragment_name).with(content: /Host "customer\[0-9\]\+"/)
+      should contain_concat__fragment(concat_fragment_name).with(content: /Plugin "\^foobar\$"/)
+    end
+  end
+
+  context 'Add match empty_counter to rule without options' do
+    let(:params) do
+      default_params.merge(plugin: 'empty_counter')
+    end
+    it 'Will ensure that plugin is loaded' do
+      should contain_collectd__plugin('match_empty_counter').with(order: '02')
+    end
+    it 'Will add match to rule' do
+      should contain_concat__fragment(concat_fragment_name).with(
+        order: concat_fragment_order,
+        target: concat_fragment_target
+      )
+      should contain_concat__fragment(concat_fragment_name).with(content: /Match "empty_counter"/)
+    end
+  end
+end

--- a/spec/defines/collectd_plugin_filter_rule_spec.rb
+++ b/spec/defines/collectd_plugin_filter_rule_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'collectd::plugin::filter::rule', type: :define do
+  let :facts do
+    {
+      osfamily: 'Debian',
+      concat_basedir: tmpfilename('collectd-filter'),
+      id: 'root',
+      kernel: 'Linux',
+      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      collectd_version: '5.0'
+    }
+  end
+
+  let(:title) { 'MyRule' }
+  let(:params) { { chain: 'MyChain' } }
+
+  context 'Add rule' do
+    it 'create header and footer of rule' do
+      should contain_concat__fragment('/etc/collectd/conf.d/filter-chain-MyChain.conf_10_MyRule_0').with(
+        order: '10_MyRule_0',
+        content: '  <Rule "MyRule">',
+        target: '/etc/collectd/conf.d/filter-chain-MyChain.conf'
+      )
+      should contain_concat__fragment('/etc/collectd/conf.d/filter-chain-MyChain.conf_10_MyRule_99').with(
+        order: '10_MyRule_99',
+        content: '  </Rule>',
+        target: '/etc/collectd/conf.d/filter-chain-MyChain.conf'
+      )
+    end
+  end
+end

--- a/spec/defines/collectd_plugin_filter_target_spec.rb
+++ b/spec/defines/collectd_plugin_filter_target_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe 'collectd::plugin::filter::target', type: :define do
+  let :facts do
+    {
+      osfamily: 'Debian',
+      concat_basedir: tmpfilename('collectd-filter'),
+      id: 'root',
+      kernel: 'Linux',
+      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      collectd_version: '5.0'
+    }
+  end
+
+  let(:title) { 'MyTarget' }
+  let(:default_params) { { chain: 'MyChain' } }
+  let(:concat_fragment_target) { '/etc/collectd/conf.d/filter-chain-MyChain.conf' }
+
+  context 'Add target set to rule with options' do
+    let(:concat_fragment_order) { '10_MyRule_30_MyTarget' }
+    let(:concat_fragment_name) { '/etc/collectd/conf.d/filter-chain-MyChain.conf_10_MyRule_30_MyTarget' }
+    let(:params) do
+      default_params.merge(plugin: 'set',
+                           rule: 'MyRule',
+                           options: {
+                             'PluginInstance' => 'coretemp',
+                             'TypeInstance'   => 'core3'
+                           })
+    end
+    it 'Will ensure that plugin is loaded' do
+      should contain_collectd__plugin('target_set').with(order: '02')
+    end
+    it 'Will add target to rule' do
+      should contain_concat__fragment(concat_fragment_name).with(
+        order: concat_fragment_order,
+        target: concat_fragment_target
+      )
+      should contain_concat__fragment(concat_fragment_name).with(content: /<Target "set">/)
+      should contain_concat__fragment(concat_fragment_name).with(content: /PluginInstance "coretemp"/)
+      should contain_concat__fragment(concat_fragment_name).with(content: /TypeInstance "core3"/)
+    end
+  end
+
+  context 'Add builtin target return without rule to chain' do
+    let(:concat_fragment_order) { '20_50_MyTarget' }
+    let(:concat_fragment_name) { '/etc/collectd/conf.d/filter-chain-MyChain.conf_20_50_MyTarget' }
+    let(:params) do
+      default_params.merge(plugin: 'return')
+    end
+    it 'Builtin plugin should not be tried to load' do
+      should_not contain_collectd__plugin('target_return')
+    end
+    it 'Will add target to chain' do
+      should contain_concat__fragment(concat_fragment_name).with(
+        order: concat_fragment_order,
+        target: concat_fragment_target
+      )
+      should contain_concat__fragment(concat_fragment_name).with(content: /Target "return"/)
+    end
+  end
+end

--- a/templates/plugin/filter/match.erb
+++ b/templates/plugin/filter/match.erb
@@ -1,0 +1,15 @@
+<% if @options.nil? -%>
+    Match "<%= @plugin %>"
+<% else -%>
+    <Match "<%= @plugin %>">
+<%  @options.each do |key, value| -%>
+<%    if value.kind_of?(String) -%>
+      <%= key %> "<%= value %>"
+<%    elsif value.kind_of?(Integer) or value.kind_of?(TrueClass) or value.kind_of?(FalseClass) -%>
+      <%= key %> <%= value %>
+<%    elsif value.kind_of?(Array) -%>
+      <%= key %> <%= value.flatten.map {|entry| "\"#{entry}\""}.join(' ') %>
+<%    end -%>
+<%  end -%>
+    </Match>
+<% end -%>

--- a/templates/plugin/filter/target.erb
+++ b/templates/plugin/filter/target.erb
@@ -1,0 +1,15 @@
+<% if @options.nil? -%>
+    Target "<%= @plugin %>"
+<% else -%>
+    <Target "<%= @plugin %>">
+<%  @options.each do |key, value| -%>
+<%    if value.kind_of?(String) -%>
+      <%= key %> "<%= value %>"
+<%    elsif value.kind_of?(Integer) or value.kind_of?(TrueClass) or value.kind_of?(FalseClass) -%>
+      <%= key %> <%= value %>
+<%    elsif value.kind_of?(Array) -%>
+      <%= key %> <%= value.flatten.map {|entry| "\"#{entry}\""}.join(' ') %>
+<%    end -%>
+<%  end -%>
+    </Target>
+<% end -%>


### PR DESCRIPTION
The Chain plugin is nice, but i was missing some flexibility. 
This is a new plugin which manages the creation of the whole filter configuration. Its splitted to multiple resources to create a whole chain: chain, rule, match, target.