### PR TITLE
Add support for the new AllPortsSummary option.

### DIFF
--- a/manifests/plugin/tcpconns.pp
+++ b/manifests/plugin/tcpconns.pp
@@ -1,10 +1,11 @@
 # https://collectd.org/wiki/index.php/Plugin:TCPConns
 class collectd::plugin::tcpconns (
-  $localports  = undef,
-  $remoteports = undef,
-  $listening   = undef,
-  $interval    = undef,
-  $ensure      = present
+  $localports      = undef,
+  $remoteports     = undef,
+  $listening       = undef,
+  $interval        = undef,
+  $allportssummary = undef,
+  $ensure          = present
 ) {
 
   if $localports {
@@ -13,6 +14,10 @@ class collectd::plugin::tcpconns (
 
   if $remoteports {
     validate_array($remoteports)
+  }
+
+  if $allportssummary {
+    validate_bool($allportssummary)
   }
 
   collectd::plugin {'tcpconns':

--- a/spec/classes/collectd_plugin_tcpconns_spec.rb
+++ b/spec/classes/collectd_plugin_tcpconns_spec.rb
@@ -60,5 +60,40 @@ describe 'collectd::plugin::tcpconns', :type => :class do
       should compile.and_raise_error(/String/)
     end
   end
+  
+  context ':allportssummary is not a boolean' do
+    let :params do
+      { :allportssummary => 'aString' }
+    end
+    it 'Will raise an error about :allportssummary being a String' do
+      expect { should.to raise_error(Puppet::Error,/String/) }
+    end
+  end
+
+  context ':allportssummary => true with collectd_version < 5.5.0' do
+    let :facts do
+      { :osfamily => 'RedHat', :collectd_version => '5.4.1' }
+    end
+    let :params do
+      { :ensure  => 'present', :allportssummary => true }
+    end
+
+    it 'Should not include AllPortsSummary in /etc/collectd.d/10-tcpconns.conf' do
+      should contain_file('tcpconns.load').without_content(/AllPortsSummary/)
+    end
+  end
+
+  context ':allportssummary => true with collectd_version = 5.5.0' do
+    let :facts do
+      { :osfamily => 'RedHat', :collectd_version => '5.5.0' }
+    end
+    let :params do
+      { :ensure  => 'present', :allportssummary => true }
+    end
+
+    it 'Should include AllPortsSummary in /etc/collectd.d/10-tcpconns.conf' do
+      should contain_file('tcpconns.load').with_content(/AllPortsSummary true/)
+    end
+  end
 end
 

--- a/templates/plugin/tcpconns.conf.erb
+++ b/templates/plugin/tcpconns.conf.erb
@@ -13,4 +13,7 @@
   RemotePort "<%= remoteport %>"
 <%   end -%>
 <% end -%>
+<% if @allportssummary and @collectd_version and (scope.function_versioncmp([@collectd_version, '5.5.0']) >= 0) -%>
+  AllPortsSummary <%= @allportssummary %>
+<% end -%>
 </Plugin>


### PR DESCRIPTION
Add support for the allportssummary option added to the tcpconns module introduced in version collectd-5.5.0.