### PR TITLE
SNMP template typo fix s/Shitf/Shift/

### DIFF
--- a/templates/plugin/snmp.conf.erb
+++ b/templates/plugin/snmp.conf.erb
@@ -14,8 +14,8 @@
 <% if val['Scale'] -%>
     Scale <%= val['Scale'] %>
 <% end -%>
-<% if val['Shitf'] -%>
-    Shitf <%= val['Shitf'] %>
+<% if val['Shift'] -%>
+    Shift <%= val['Shift'] %>
 <% end -%>
   </Data>
 <% end -%>


### PR DESCRIPTION
Fix a minor typo in the snmp.conf.erb template.