### PR TITLE
Make the management of the collectd package optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,7 @@ class collectd (
   $service_ensure         = $collectd::params::service_ensure,
   $service_enable         = $collectd::params::service_enable,
   $minimum_version        = $collectd::params::minimum_version,
+  $manage_package         = $collectd::params::manage_package,
 ) inherits collectd::params {
 
   validate_bool($purge_config, $fqdnlookup)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,12 +2,15 @@ class collectd::install (
   $version          = $collectd::version,
   $package_name     = $collectd::package_name,
   $package_provider = $collectd::package_provider,
+  $manage_package   = $collectd::manage_package,
 ) {
 
-  package { $package_name:
-    ensure   => $version,
-    name     => $package_name,
-    provider => $package_provider,
+  if $manage_package {
+    package { $package_name:
+      ensure   => $version,
+      name     => $package_name,
+      provider => $package_provider,
+    }
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,6 +18,7 @@ class collectd::params {
   $service_ensure         = running
   $service_enable         = true
   $minimum_version        = undef
+  $manage_package         = true
 
   case $::osfamily {
     'Debian': {

--- a/manifests/plugin/amqp.pp
+++ b/manifests/plugin/amqp.pp
@@ -1,6 +1,7 @@
 # https://collectd.org/wiki/index.php/Plugin:AMQP
 class collectd::plugin::amqp (
   $ensure          = present,
+  $manage_package  = $true,
   $amqphost        = 'localhost',
   $amqpport        = 5672,
   $amqpvhost       = 'graphite',
@@ -17,8 +18,10 @@ class collectd::plugin::amqp (
   validate_bool($amqppersistent)
 
   if $::osfamily == 'Redhat' {
-    package { 'collectd-amqp':
-      ensure => $ensure,
+    if $manage_package {
+      package { 'collectd-amqp':
+        ensure => $ensure,
+      }
     }
   }
 

--- a/manifests/plugin/apache.pp
+++ b/manifests/plugin/apache.pp
@@ -1,15 +1,18 @@
 # https://collectd.org/wiki/index.php/Plugin:Apache
 class collectd::plugin::apache (
-  $ensure     = present,
-  $instances  = { 'localhost' => { 'url' => 'http://localhost/mod_status?auto' } },
-  $interval   = undef,
+  $ensure         = present,
+  $manage_package = $true,
+  $instances      = { 'localhost' => { 'url' => 'http://localhost/mod_status?auto' } },
+  $interval       = undef,
 ) {
 
   validate_hash($instances)
 
   if $::osfamily == 'RedHat' {
-    package { 'collectd-apache':
-      ensure => $ensure,
+    if $manage_package {
+      package { 'collectd-apache':
+        ensure => $ensure,
+      }
     }
   }
 

--- a/manifests/plugin/bind.pp
+++ b/manifests/plugin/bind.pp
@@ -2,6 +2,7 @@
 class collectd::plugin::bind (
   $url,
   $ensure         = present,
+  $manage_package = $true,
   $memorystats    = true,
   $opcodes        = true,
   $parsetime      = false,
@@ -25,8 +26,10 @@ class collectd::plugin::bind (
   validate_array($views)
 
   if $::osfamily == 'Redhat' {
-    package { 'collectd-bind':
-      ensure => $ensure,
+    if $manage_package {
+      package { 'collectd-bind':
+        ensure => $ensure,
+      }
     }
   }
 

--- a/manifests/plugin/curl.pp
+++ b/manifests/plugin/curl.pp
@@ -1,13 +1,16 @@
 #
 class collectd::plugin::curl (
-  $ensure   = present,
-  $interval = undef,
-  $pages    = { },
+  $ensure         = present,
+  $manage_package = $true,
+  $interval       = undef,
+  $pages          = { },
 ) {
 
   if $::osfamily == 'Redhat' {
-    package { 'collectd-curl':
-      ensure => $ensure,
+    if $manage_package {
+      package { 'collectd-curl':
+        ensure => $ensure,
+      }
     }
   }
 

--- a/manifests/plugin/iptables.pp
+++ b/manifests/plugin/iptables.pp
@@ -1,15 +1,18 @@
 # https://collectd.org/wiki/index.php/Plugin:IPTables
 class collectd::plugin::iptables (
-  $ensure   = present,
+  $ensure         = present,
   $ensure_package = present,
-  $chains   = {},
-  $interval = undef,
+  $manage_package = $true,
+  $chains         = {},
+  $interval       = undef,
 ) {
   validate_hash($chains)
 
   if $::osfamily == 'Redhat' {
-    package { 'collectd-iptables':
-      ensure => $ensure_package,
+    if $manage_package {
+      package { 'collectd-iptables':
+        ensure => $ensure_package,
+      }
     }
   }
 

--- a/manifests/plugin/libvirt.pp
+++ b/manifests/plugin/libvirt.pp
@@ -2,6 +2,7 @@
 class collectd::plugin::libvirt (
   $connection,
   $ensure           = present,
+  $manage_package   = $true,
   $refresh_interval = undef,
   $domain           = undef,
   $block_device     = undef,
@@ -22,8 +23,10 @@ class collectd::plugin::libvirt (
   if $interface_format != undef { validate_string($interface_format) }
 
   if $::osfamily == 'RedHat' {
-    package { 'collectd-virt':
-      ensure => $ensure,
+    if $manage_package {
+      package { 'collectd-virt':
+        ensure => $ensure,
+      }
     }
   }
 

--- a/manifests/plugin/lvm.pp
+++ b/manifests/plugin/lvm.pp
@@ -1,12 +1,15 @@
 # https://collectd.org/wiki/index.php/Plugin:LVM
 class collectd::plugin::lvm (
-  $ensure   = present,
-  $interval = undef,
+  $ensure           = present,
+  $manage_package   = $true,
+  $interval         = undef,
 ) {
 
   if $::osfamily == 'Redhat' {
-    package { 'collectd-lvm':
-      ensure => $ensure,
+    if $manage_package {
+      package { 'collectd-lvm':
+        ensure => $ensure,
+      }
     }
   }
 

--- a/manifests/plugin/mysql.pp
+++ b/manifests/plugin/mysql.pp
@@ -1,13 +1,16 @@
 # MySQL plugin
 # https://collectd.org/wiki/index.php/Plugin:MySQL
 class collectd::plugin::mysql (
-  $ensure = present,
-  $interval = undef,
+  $ensure           = present,
+  $manage_package   = $true,
+  $interval         = undef,
 ){
 
   if $::osfamily == 'Redhat' {
-    package { 'collectd-mysql':
-      ensure => $ensure,
+    if $manage_package {
+      package { 'collectd-mysql':
+        ensure => $ensure,
+      }
     }
   }
 

--- a/manifests/plugin/netlink.pp
+++ b/manifests/plugin/netlink.pp
@@ -1,6 +1,7 @@
 # https://collectd.org/wiki/index.php/Plugin:Netlink
 class collectd::plugin::netlink (
   $ensure            = present,
+  $manage_package    = true,
   $interfaces        = [],
   $verboseinterfaces = [],
   $qdiscs            = [],
@@ -14,8 +15,10 @@ class collectd::plugin::netlink (
   validate_bool($ignoreselected)
 
   if $::osfamily == 'Redhat' {
-    package { 'collectd-netlink':
-      ensure => $ensure,
+    if $manage_package {
+      package { 'collectd-netlink':
+        ensure => $ensure,
+      }
     }
   }
 

--- a/manifests/plugin/nginx.pp
+++ b/manifests/plugin/nginx.pp
@@ -1,18 +1,21 @@
 # https://collectd.org/wiki/index.php/Plugin:nginx
 class collectd::plugin::nginx (
   $url,
-  $ensure     = present,
-  $user       = undef,
-  $password   = undef,
-  $verifypeer = undef,
-  $verifyhost = undef,
-  $cacert     = undef,
-  $interval   = undef,
+  $manage_package   = $true,
+  $ensure           = present,
+  $user             = undef,
+  $password         = undef,
+  $verifypeer       = undef,
+  $verifyhost       = undef,
+  $cacert           = undef,
+  $interval         = undef,
 ) {
 
   if $::osfamily == 'Redhat' {
-    package { 'collectd-nginx':
-      ensure => $ensure,
+    if $manage_package {
+      package { 'collectd-nginx':
+        ensure => $ensure,
+      }
     }
   }
 

--- a/manifests/plugin/perl.pp
+++ b/manifests/plugin/perl.pp
@@ -1,16 +1,19 @@
 # See http://collectd.org/documentation/manpages/collectd-perl.5.shtml
 class collectd::plugin::perl (
-  $ensure   = present,
-  $interval = undef,
-  $order    = 20
+  $ensure           = present,
+  $manage_package   = $true,
+  $interval         = undef,
+  $order            = 20
 )
 {
   include collectd::params
   $conf_dir = $collectd::params::plugin_conf_dir
 
   if $::osfamily == 'Redhat' {
-    package { 'collectd-perl':
-      ensure => $ensure,
+    if $manage_package {
+      package { 'collectd-perl':
+        ensure => $ensure,
+      }
     }
   }
 

--- a/manifests/plugin/perl/plugin.pp
+++ b/manifests/plugin/perl/plugin.pp
@@ -1,6 +1,7 @@
 #
 define collectd::plugin::perl::plugin (
   $module,
+  $manage_package = true,
   $enable_debugger = false,
   $include_dir = false,
   $provider = false,
@@ -45,8 +46,10 @@ define collectd::plugin::perl::plugin (
   case $provider {
     'package': {
       validate_string($source)
-      package { $source:
-        require => Collectd::Plugin['perl'],
+      if $manage_package {
+        package { $source:
+          require => Collectd::Plugin['perl'],
+        }
       }
     }
     'cpan': {
@@ -76,7 +79,7 @@ define collectd::plugin::perl::plugin (
     }
     default: {
       fail("Unsupported provider: ${provider}. Use 'package', 'cpan',
-        'file' or false.")
+      'file' or false.")
     }
   }
 }

--- a/manifests/plugin/ping.pp
+++ b/manifests/plugin/ping.pp
@@ -2,6 +2,7 @@
 define collectd::plugin::ping (
   $hosts,
   $ensure         = present,
+  $manage_package = $true,
   $interval       = undef,
   $timeout        = undef,
   $ttl            = undef,
@@ -14,8 +15,10 @@ define collectd::plugin::ping (
   validate_array($hosts)
 
   if $::osfamily == 'Redhat' {
-    package { 'collectd-ping':
-      ensure => $ensure,
+    if $manage_package {
+      package { 'collectd-ping':
+        ensure => $ensure,
+      }
     }
   }
 

--- a/manifests/plugin/postgresql.pp
+++ b/manifests/plugin/postgresql.pp
@@ -1,16 +1,19 @@
 # https://collectd.org/wiki/index.php/Plugin:PostgreSQL
 class collectd::plugin::postgresql (
-  $ensure    = present,
-  $databases = { },
-  $interval  = undef,
-  $queries   = { },
-  $writers   = { },
+  $ensure         = present,
+  $manage_package = $true,
+  $databases      = { },
+  $interval       = undef,
+  $queries        = { },
+  $writers        = { },
 ) {
   include collectd::params
 
   if $::osfamily == 'Redhat' {
-    package { 'collectd-postgresql':
-      ensure => $ensure,
+    if $manage_package {
+      package { 'collectd-postgresql':
+        ensure => $ensure,
+      }
     }
   }
 

--- a/manifests/plugin/rrdtool.pp
+++ b/manifests/plugin/rrdtool.pp
@@ -1,6 +1,7 @@
 # https://collectd.org/wiki/index.php/Plugin:RRDtool
 class collectd::plugin::rrdtool (
   $ensure           = present,
+  $manage_package   = true,
   $datadir          = '/var/lib/collectd/rrd',
   $createfilesasync = false,
   $interval         = undef,
@@ -44,8 +45,10 @@ class collectd::plugin::rrdtool (
   }
 
   if $::osfamily == 'RedHat' {
-    package { 'collectd-rrdtool':
-      ensure => $ensure,
+    if $manage_package {
+      package { 'collectd-rrdtool':
+        ensure => $ensure,
+      }
     }
   }
 

--- a/manifests/plugin/sensors.pp
+++ b/manifests/plugin/sensors.pp
@@ -1,6 +1,7 @@
 # https://collectd.org/wiki/index.php/Plugin:Sensors
 class collectd::plugin::sensors (
   $ensure           = present,
+  $manage_package   = $true,
   $sensorconfigfile = undef,
   $sensor           = undef,
   $ignoreselected   = undef,
@@ -8,8 +9,10 @@ class collectd::plugin::sensors (
 ) {
 
   if $::osfamily == 'Redhat' {
-    package { 'collectd-sensors':
-      ensure => $ensure,
+    if $manage_package {
+      package { 'collectd-sensors':
+        ensure => $ensure,
+      }
     }
   }
 

--- a/manifests/plugin/snmp.pp
+++ b/manifests/plugin/snmp.pp
@@ -1,13 +1,16 @@
 # https://collectd.org/wiki/index.php/Plugin:SNMP
 class collectd::plugin::snmp (
-  $ensure   = present,
-  $data     = {},
-  $hosts    = {},
-  $interval = undef,
+  $ensure         = present,
+  $manage_package = $true,
+  $data           = {},
+  $hosts          = {},
+  $interval       = undef,
 ) {
   if $::osfamily == 'Redhat' {
-    package { 'collectd-snmp':
-      ensure => $ensure,
+    if $manage_package {
+      package { 'collectd-snmp':
+        ensure => $ensure,
+      }
     }
   }
 

--- a/manifests/plugin/varnish.pp
+++ b/manifests/plugin/varnish.pp
@@ -1,19 +1,22 @@
 # https://collectd.org/wiki/index.php/Plugin:Varnish
 class collectd::plugin::varnish (
-  $ensure    = present,
-  $instances = {
-      'localhost' => {
-      }
-    },
-  $interval = undef,
+  $ensure         = present,
+  $manage_package = $true,
+  $instances      = {
+    'localhost' => {
+    }
+  },
+  $interval       = undef,
 ) {
   include collectd::params
 
   validate_hash($instances)
 
   if $::osfamily == 'Redhat' {
-    package { 'collectd-varnish':
-      ensure => $ensure,
+    if $manage_package {
+      package { 'collectd-varnish':
+        ensure => $ensure,
+      }
     }
   }
 

--- a/manifests/plugin/write_riemann.pp
+++ b/manifests/plugin/write_riemann.pp
@@ -1,6 +1,7 @@
 # https://collectd.org/wiki/index.php/Plugin:Write_Riemann
 class collectd::plugin::write_riemann (
   $ensure           = present,
+  $manage_package   = $true,
   $riemann_host     = 'localhost',
   $riemann_port     = 5555,
   $protocol         = 'UDP',
@@ -12,8 +13,10 @@ class collectd::plugin::write_riemann (
   validate_bool($always_append_ds)
 
   if $::osfamily == 'Redhat' {
-    package { 'collectd-write_riemann':
-      ensure => $ensure,
+    if $manage_package {
+      package { 'collectd-write_riemann':
+        ensure => $ensure,
+      }
     }
   }
 

--- a/manifests/plugin/write_sensu.pp
+++ b/manifests/plugin/write_sensu.pp
@@ -1,6 +1,7 @@
 # https://collectd.org/wiki/index.php/Plugin:Write_Riemann
 class collectd::plugin::write_sensu (
   $ensure           = present,
+  $manage_package   = $true,
   $sensu_host       = 'localhost',
   $sensu_port       = 3030,
   $store_rates      = false,
@@ -15,8 +16,10 @@ class collectd::plugin::write_sensu (
   validate_bool($always_append_ds)
 
   if $::osfamily == 'Redhat' {
-    package { 'collectd-write_sensu':
-      ensure => $ensure,
+    if $manage_package {
+      package { 'collectd-write_sensu':
+        ensure => $ensure,
+      }
     }
   }
 

--- a/spec/classes/collectd_init_spec.rb
+++ b/spec/classes/collectd_init_spec.rb
@@ -82,4 +82,14 @@ describe 'collectd' do
     let(:params) {{:package_name => 'collectd-core'}}
     it { should contain_package('collectd-core').with_ensure('installed') }
   end
+
+ context 'when manage_package is false' do
+   let(:params) {{ :manage_package => false }}
+   it { should_not contain_package('collectd')}
+ end
+
+ context 'when manage_package is true' do
+   let(:params) {{ :manage_package => true }}
+   it { should contain_package('collectd').with_ensure('installed')}
+ end
 end


### PR DESCRIPTION
Sometimes installing packages is done in a different way (eg. epel may
not be enabled by default)

The dependencies still hold.