### PR TITLE
Fix rspec tests to use new collectd_real_version fact

### DIFF
--- a/spec/classes/collectd_init_spec.rb
+++ b/spec/classes/collectd_init_spec.rb
@@ -64,14 +64,14 @@ describe 'collectd' do
     end
 
     context 'with internal_stats => true' do
-      context 'with collectd_version = 5.5' do
-        let(:facts) {{:osfamily => 'RedHat', :collectd_version => '5.5'}}
+      context 'with collectd_real_version = 5.5' do
+        let(:facts) {{:osfamily => 'RedHat', :collectd_real_version => '5.5'}}
         let(:params) {{:purge_config => true, :internal_stats => true}}
         it { is_expected.to contain_file('collectd.conf').without_content /^CollectInternalStats/ }
       end
 
-      context 'with collectd_version = 5.6' do
-        let(:facts) {{:osfamily => 'RedHat', :collectd_version => '5.6'}}
+      context 'with collectd_real_version = 5.6' do
+        let(:facts) {{:osfamily => 'RedHat', :collectd_real_version => '5.6'}}
         let(:params) {{:purge_config => true, :internal_stats => true}}
         it { is_expected.to contain_file('collectd.conf').with_content /^CollectInternalStats true/ }
       end


### PR DESCRIPTION
* When PR #305 was merged to master, it was based on an older master branch
A couple of tests had been added to the init class in the interim that were not updated with the merge.

This commit fixes those two tests