### PR TITLE
Fixing duplicate param and some housekeeping

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,6 +369,3 @@ DEPENDENCIES
   rspec-puppet-facts
   travis
   travis-lint
-
-BUNDLED WITH
-   1.10.6

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,8 +22,7 @@ class collectd (
   $service_name           = $collectd::params::service_name,
   $service_ensure         = $collectd::params::service_ensure,
   $service_enable         = $collectd::params::service_enable,
-  $version                = installed,
-  $minimum_version        = undef,
+  $minimum_version        = $collectd::params::minimum_version,
 ) inherits collectd::params {
 
   validate_bool($purge_config, $fqdnlookup)
@@ -33,7 +32,7 @@ class collectd (
   $collectd_version = pick(
     $::collectd_real_version,                                                      # Fact takes precedence
     regsubst(
-      regsubst($version,'^(absent|held|installed|latest|present|purged)$', ''), # standard package resource ensure value? - strip and return undef
+      regsubst($version,'^(absent|held|installed|latest|present|purged)$', ''),    # standard package resource ensure value? - strip and return undef
       '^\d+(?:\.\d+){1.2}', '\0'),                                                 # specific package version? return only semantic version parts
     $minimum_version,
     '1.0')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,7 @@ class collectd::params {
   $version                = installed
   $service_ensure         = running
   $service_enable         = true
+  $minimum_version        = undef
 
   case $::osfamily {
     'Debian': {


### PR DESCRIPTION
Hauskeeping! This commit removes a duplicate $version paramter. It
also moves the $minimum_version default to the params class and
aligns an inline comment.