### PR TITLE
use the correct collectd_version in templates

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,3 +1,4 @@
+# private
 class collectd::config (
   $config_file            = $collectd::config_file,
   $plugin_conf_dir        = $collectd::plugin_conf_dir,
@@ -15,6 +16,7 @@ class collectd::config (
   $write_queue_limit_high = $collectd::write_queue_limit_high,
   $write_queue_limit_low  = $collectd::write_queue_limit_low,
   $internal_stats         = $collectd::internal_stats,
+  $collectd_version       = $collectd::collectd_version,
 ) {
 
   $conf_content = $purge_config ? {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,7 +38,9 @@ class collectd (
     '1.0')
 
   class { 'collectd::install': } ->
-  class { 'collectd::config': } ~>
+  class { 'collectd::config':
+    collectd_version => $collectd_version,
+  } ~>
   class { 'collectd::service': }
 
 }

--- a/templates/collectd.conf.erb
+++ b/templates/collectd.conf.erb
@@ -26,6 +26,6 @@ Include "<%= @plugin_conf_dir %>/*.conf"
 <% @include.each do |obj| -%>
 Include "<%= obj %>"
 <% end -%>
-<% if @internal_stats && @collectd_real_version && scope.function_versioncmp([@collectd_real_version, '5.5']) > 0 -%>
+<% if @internal_stats && @collectd_version && scope.function_versioncmp([@collectd_version, '5.5']) > 0 -%>
 CollectInternalStats true
 <% end -%>


### PR DESCRIPTION
the template shouldn't use collectd_real_version
actually, nothing should use collectd_real_version.
collectd_version is there to normalize a potentially empty value.