### PR TITLE
modulesync integration: spec_helper unmanaged for now

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,3 +1,5 @@
 ---
 .travis.yml:
   secure: "FAK3Izs5bSZyblGvcFnGWm0exZV5+v9pbwfRDD2oihWxX3U3pArGW+3XcwcJfLQgrUYBsOTmHC8yPjlgTBYeIt/5pvg9X+3jwNgeto6kozpI/nvAq4NtcHhzxRejuPELhFYeXZ3hEw0w+v/ZRo2cNLwI0LLpiWEDvCMZN1CJ2RY="
+spec/spec_helper.rb:
+  unmanaged: true


### PR DESCRIPTION
once we decide that this is useful to the general public we should just
make sure it ends up in spec_helper