### PR TITLE
Solaris variables

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,7 +38,7 @@ class collectd::params {
       $provider          = 'pkgutil'
       $collectd_dir      = '/etc/opt/csw'
       $plugin_conf_dir   = "${collectd_dir}/conf.d"
-      $service_name      = 'collectd'
+      $service_name      = 'cswcollectd'
       $config_file       = "${collectd_dir}/collectd.conf"
       $root_group        = 'root'
       $java_dir          = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,10 +36,10 @@ class collectd::params {
     'Solaris': {
       $package           = 'CSWcollectd'
       $provider          = 'pkgutil'
-      $collectd_dir      = '/etc/opt/csw'
-      $plugin_conf_dir   = "${collectd_dir}/conf.d"
+      $collectd_dir      = '/etc/opt/csw/collectd.d'
+      $plugin_conf_dir   = $collectd_dir
       $service_name      = 'cswcollectd'
-      $config_file       = "${collectd_dir}/collectd.conf"
+      $config_file       = '/etc/opt/csw/collectd.conf'
       $root_group        = 'root'
       $java_dir          = undef
       $python_dir        = '/opt/csw/share/collectd/python'


### PR DESCRIPTION
# Fix service name

With the current name I get:

```sh
root@host:~# /usr/sbin/svcadm enable -s collectd
svcadm: Pattern 'collectd' doesn't match any instances
```

# Fix the config file location

The current settings are equivalent to dropping a directory named 'conf.d' into
'/etc' which makes in nonobvious to which package it belongs.