### PR TITLE
[filecount] do not an emit empty <Plugin> block

### DIFF
--- a/spec/classes/collectd_plugin_filecount_spec.rb
+++ b/spec/classes/collectd_plugin_filecount_spec.rb
@@ -57,4 +57,11 @@ describe 'collectd::plugin::filecount', :type => :class do
       should compile.and_raise_error(/String/)
     end
   end
+
+  context ':directories is empty' do
+    it 'Will not create an empty <Plugin "filecount"> block' do
+      should contain_file('filecount.load')
+        .without_content(/<Plugin "filecount">/)
+    end
+  end
 end

--- a/templates/plugin/filecount.conf.erb
+++ b/templates/plugin/filecount.conf.erb
@@ -1,3 +1,4 @@
+<%- unless @directories.empty? -%>
 <Plugin "filecount">
 <% @directories.each_pair do |key,val| -%>
 <%   if val.is_a? Array -%>
@@ -11,3 +12,4 @@
 <%   end -%>
 <% end -%>
 </Plugin>
+<%- end -%>


### PR DESCRIPTION
Our collectd 4.1 chokes on an empty Plugin block.
This can happen when not using the `directories` parameter to
collectd::plugin::filecount and instead using only
collectd::plugin::filecount::directory .