### PR TITLE
collectd may fail to start in wheezy if processes-plugin is used ...

### DIFF
--- a/manifests/plugin/processes.pp
+++ b/manifests/plugin/processes.pp
@@ -17,8 +17,14 @@ class collectd::plugin::processes (
     interval => $interval,
   }
 
+  if ( $processes or $process_matches ) {
+    $process_config_ensure = present
+  } else {
+    $process_config_ensure = absent
+  }
+
   concat{"${collectd::params::plugin_conf_dir}/processes-config.conf":
-    ensure         => $ensure,
+    ensure         => $process_config_ensure,
     mode           => '0640',
     owner          => 'root',
     group          => $collectd::params::root_group,
@@ -26,18 +32,17 @@ class collectd::plugin::processes (
     ensure_newline => true,
   }
   concat::fragment{'collectd_plugin_processes_conf_header':
-    ensure  => $ensure,
+    ensure  => $process_config_ensure,
     order   => '00',
     content => '<Plugin processes>',
     target  => "${collectd::params::plugin_conf_dir}/processes-config.conf",
   }
   concat::fragment{'collectd_plugin_processes_conf_footer':
-    ensure  => $ensure,
+    ensure  => $process_config_ensure,
     order   => '99',
     content => '</Plugin>',
     target  => "${collectd::params::plugin_conf_dir}/processes-config.conf",
   }
-
 
   if $processes {
     collectd::plugin::processes::process { $processes : }


### PR DESCRIPTION
collectd may fail to start in wheezy if proccesses-plugin is used without any processes.

      root@puppetclient:/etc/collectd/conf.d# collectd -f
      Parse error in file `/etc/collectd/conf.d/processes-config.conf', line 104 near `/': syntax error, unexpected SLASH, expecting UNQUOTED_STRING
      yyparse returned error #1 
      configfile: Cannot read file `/etc/collectd/conf.d/processes-config.conf'.

Problem: creating a processes-config.conf without any configured processes is unnecessary and leads to above error (at least in wheezy).

Solution: create a processes-config.conf only if there are processes configured.

Thanks,

Fabian
