### PR TITLE
removed group naming from regex for compatibility

### DIFF
--- a/lib/facter/collectd_real_version.rb
+++ b/lib/facter/collectd_real_version.rb
@@ -9,7 +9,7 @@
 Facter.add(:collectd_real_version) do
   setcode do
     if Facter::Util::Resolution.which('collectd')
-      collectd_help = Facter::Util::Resolution.exec('collectd -h') and collectd_help =~ %r{^collectd ([\w.]+), http://collectd\.org/}
+      collectd_help = Facter::Util::Resolution.exec('collectd -h') && collectd_help =~ %r{^collectd ([\w.]+), http://collectd\.org/}
       Regexp.last_match(1)
     end
   end

--- a/lib/facter/collectd_real_version.rb
+++ b/lib/facter/collectd_real_version.rb
@@ -9,8 +9,8 @@
 Facter.add(:collectd_real_version) do
   setcode do
     if Facter::Util::Resolution.which('collectd')
-      collectd_help = Facter::Util::Resolution.exec('collectd -h')
-      %r{^collectd (?<version>[\w.]+), http://collectd.org/}.match(collectd_help)[:version]
+      collectd_help = Facter::Util::Resolution.exec('collectd -h') and collectd_help =~ %r{^collectd ([\w.]+), http://collectd\.org/}
+      Regexp.last_match(1)
     end
   end
 end


### PR DESCRIPTION
Naming a regex group within the regex itself using the '?<>' syntax only works on ruby >= 1.9.2.
I have removed the group naming.
Also escaped the dot in the url.