### PR TITLE
removed group naming from regex for compatibility with ruby 1.8.7

### DIFF
--- a/lib/facter/collectd_real_version.rb
+++ b/lib/facter/collectd_real_version.rb
@@ -10,7 +10,7 @@ Facter.add(:collectd_real_version) do
   setcode do
     if Facter::Util::Resolution.which('collectd')
       collectd_help = Facter::Util::Resolution.exec('collectd -h')
-      %r{^collectd (?<version>[\w.]+), http://collectd.org/}.match(collectd_help)[:version]
+      %r{^collectd ([\w\.]+), http://collectd\.org/}.match(collectd_help)[1]
     end
   end
 end


### PR DESCRIPTION
ruby 1.8.7 does noet support regex group naming