### PR TITLE
Fix empty Database-names in dbi-plugin

### DIFF
--- a/manifests/plugin/dbi/database.pp
+++ b/manifests/plugin/dbi/database.pp
@@ -4,6 +4,7 @@ define collectd::plugin::dbi::database (
   $driver,
   $ensure       = 'present',
   $host         = undef,
+  $databasename = $name,
   $driveroption = {},
   $selectdb     = undef,
   $query        = [],


### PR DESCRIPTION
Right now, this pseudo Puppet-code:

	::collectd::plugin::dbi::query { 'test': ... }
	::collectd::plugin::dbi::database { 'test':
		driver => 'mysql',
		driveroption => {
			'host' => 'localhost',
			'mysql_unix_socket' => ...,
			'username' => ...,
			'password' => ...,
			'dbname' => ...,
		},
		query => [ 'test' ],
	}

produces these configuration blocks:

	<Plugin dbi>
		<Query test>
			...
		</Query>
		<Database "">       <-----
			...
		</Database>
	</Plugin>

The database-name references a non-existent @databasename variable, so introduce
this variable, as it is also introduced and used inside
::collectd::postgresql::database, so that the expected output is produced:

	<Plugin dbi>
		<Query test>
			...
		</Query>
		<Database "test">   <-----
			...
		</Database>
	</Plugin>