### PR TITLE
Allow changing of the file mode of the collectd plugin directory and custom typesdb files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1467,6 +1467,15 @@ class { 'collectd':
 }
 ```
 
+Other software may need to read the Collectd types database files. To allow non-root users to read from a `collectd::typesdb`
+file like so:
+
+```puppet
+$db = '/etc/collectd/types.db'
+collectd::typesdb { $db:
+  mode => '0644',
+}
+```
 
 ##Limitations
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,6 +2,7 @@
 class collectd::config (
   $config_file            = $collectd::config_file,
   $plugin_conf_dir        = $collectd::plugin_conf_dir,
+  $plugin_conf_dir_mode   = $collectd::plugin_conf_dir_mode,
   $root_group             = $collectd::root_group,
   $recurse                = $collectd::recurse,
   $fqdnlookup             = $collectd::fqdnlookup,
@@ -47,11 +48,10 @@ class collectd::config (
   file { 'collectd.d':
     ensure  => directory,
     path    => $plugin_conf_dir,
-    mode    => '0750',
+    mode    => $plugin_conf_dir_mode,
     owner   => 'root',
     group   => $root_group,
     purge   => $purge,
     recurse => $recurse,
   }
-
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,7 @@ class collectd (
   $package_install_options = $collectd::params::package_install_options,
   $package_name            = $collectd::params::package,
   $plugin_conf_dir         = $collectd::params::plugin_conf_dir,
+  $plugin_conf_dir_mode    = $collectd::params::plugin_conf_dir_mode,
   $root_group              = $collectd::params::root_group,
   $version                 = $collectd::params::version,
   $service_name            = $collectd::params::service_name,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,7 @@ class collectd::params {
   $minimum_version         = undef
   $manage_package          = true
   $package_install_options = undef
+  $plugin_conf_dir_mode    = '0750'
 
   case $::osfamily {
     'Debian': {

--- a/manifests/typesdb.pp
+++ b/manifests/typesdb.pp
@@ -1,5 +1,6 @@
 define collectd::typesdb (
   $path = $title,
+  $mode = '0640',
 ) {
   include collectd::params
 
@@ -8,7 +9,7 @@ define collectd::typesdb (
     ensure         => present,
     owner          => 'root',
     group          => $collectd::params::root_group,
-    mode           => '0640',
+    mode           => $mode,
     ensure_newline => true,
     force          => true,
     notify         => Service['collectd'],

--- a/spec/classes/collectd_init_spec.rb
+++ b/spec/classes/collectd_init_spec.rb
@@ -115,4 +115,9 @@ describe 'collectd' do
     let(:params) { { :manage_package => true } }
     it { should contain_package('collectd').with_ensure('installed') }
   end
+
+  context 'when plugin_conf_dir_mode is set' do
+    let(:params) { { :plugin_conf_dir_mode => '0755' } }
+    it { should contain_file('collectd.d').with_mode('0755') }
+  end
 end

--- a/spec/defines/collectd_typesdb_spec.rb
+++ b/spec/defines/collectd_typesdb_spec.rb
@@ -15,7 +15,16 @@ describe 'collectd::typesdb', :type => :define do
 
     it 'should contain empty types.db' do
       should contain_concat('/etc/collectd/types.db')
-      should contain_file('/etc/collectd/types.db')
+      should contain_file('/etc/collectd/types.db').with_mode('0640')
+    end
+  end
+
+  context 'with a different file mode' do
+    let(:title) { '/etc/collectd/types.db' }
+    let(:params) { { 'mode' => '0644' } }
+
+    it 'should contain file with different mode' do
+      should contain_file('/etc/collectd/types.db').with_mode('0644')
     end
   end
 end


### PR DESCRIPTION
Other software (InfluxDB) can be configured to read from the Collectd types database, this will allow someone to set a different file mode on both the collectd.d directory and any typesdb files this module creates. It's probably safer than changing the default file mode of File[collectd.d], I don't know if plugins store passwords in there.